### PR TITLE
Address Elixir 1.4 function ambiguity warnings

### DIFF
--- a/lib/ex_osc/logger.ex
+++ b/lib/ex_osc/logger.ex
@@ -7,7 +7,7 @@ defmodule ExOsc.Logger do
   require Logger
 
   def start_logger do
-    pid = {__MODULE__, make_ref}
+    pid = {__MODULE__, make_ref()}
     :ok = GenEvent.add_handler(:osc_events, pid, [])
     {:ok, pid}
   end

--- a/mix.exs
+++ b/mix.exs
@@ -3,14 +3,16 @@ defmodule ExOsc.Mixfile do
 
   def project do
     [ app: :ex_osc,
-      version: "0.0.1",
-      elixir: ">= 1.2.3",
-      deps: deps ]
+      version: "0.0.2",
+      elixir: ">= 1.2.6",
+      build_embedded: Mix.env == :prod,
+      start_permanent: Mix.env == :prod,
+      deps: deps() ]
   end
 
   def application do
     [
-      applications: [:logger],
+      extra_applications: [:logger],
       mod: { ExOsc, [] }
     ]
   end


### PR DESCRIPTION
Addresses the ambiguity warnings emitted by Elixir 1.4 when parenthesis
are missing from function/0 calls.

Update minimum Elixir version to 1.2.6.  App fails to start GenEvent
for prior versions.

Update version to 0.0.2